### PR TITLE
Allow `$contain` to operate on nested objects

### DIFF
--- a/lib/operations.js
+++ b/lib/operations.js
@@ -147,11 +147,13 @@ module.exports = {
   $contain: function(key, value, object) {
     'use strict';
 
-    if (!_.isString(object[key]) && !_.isArray(object[key])) {
-      throw new Error('$contain: object: not a string or array: ' + object[key]);
+    var propertyValue = _.get(object, key);
+
+    if (!_.isString(propertyValue) && !_.isArray(propertyValue)) {
+      throw new Error('$contain: object: not a string or array: ' + propertyValue);
     }
 
-    return _.some(_.map(object[key], _.partial(_.isEqual, value)));
+    return _.some(_.map(propertyValue, _.partial(_.isEqual, value)));
   },
 
   /**

--- a/tests/queryl.spec.js
+++ b/tests/queryl.spec.js
@@ -296,6 +296,85 @@ describe('Queryl:', function() {
       })).to.be.false;
     });
 
+    it('should return true for a nested array property that includes the value', function() {
+      m.chai.expect(queryl.match({
+        $contain: {
+          'foo.bar': 2
+        }
+      }, {
+        foo: {
+          bar: [ 1, 2, 3 ]
+        }
+      })).to.be.true;
+    });
+
+    it('should return false for a nested array property that does not include the value', function() {
+      m.chai.expect(queryl.match({
+        $contain: {
+          'foo.bar': 5
+        }
+      }, {
+        foo: {
+          bar: [ 1, 2, 3 ]
+        }
+      })).to.be.false;
+    });
+
+    it('should return true for a nested object array property that includes the value', function() {
+      m.chai.expect(queryl.match({
+        $contain: {
+          'foo.bar': {
+            value: 2
+          }
+        }
+      }, {
+        foo: {
+          bar: [
+            { value: 1 },
+            { value: 2 },
+            { value: 3 }
+          ]
+        }
+      })).to.be.true;
+    });
+
+    it('should return false for a nested object array property that does not include the value', function() {
+      m.chai.expect(queryl.match({
+        $contain: {
+          'foo.bar': {
+            value: 5
+          }
+        }
+      }, {
+        foo: {
+          bar: [
+            { value: 1 },
+            { value: 2 },
+            { value: 3 }
+          ]
+        }
+      })).to.be.false;
+    });
+
+    it('should return false for a nested object array that includes the value but lacks other properties', function() {
+      m.chai.expect(queryl.match({
+        $contain: {
+          'foo.bar': {
+            value: 2,
+            foo: 'bar'
+          }
+        }
+      }, {
+        foo: {
+          bar: [
+            { value: 1 },
+            { value: 2 },
+            { value: 3 }
+          ]
+        }
+      })).to.be.false;
+    });
+
   });
 
   describe('$match', function() {


### PR DESCRIPTION
Fixes: https://github.com/jviotti/queryl/issues/10
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>